### PR TITLE
README.md: use a license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Fuse.Firebase
+[![license](https://img.shields.io/github/license/cbaggers/Fuse.Firebase.svg?maxAge=2592000)]()
 
 This project is to make full Firebase bindings for Fuse.
 
@@ -16,10 +17,6 @@ See the [wiki]() for [API Docs](https://github.com/cbaggers/Fuse.Firebase/wiki/J
 - Firebase account
 
 For authentication you also need a Facebook developer account
-
-## License
-
-MIT
 
 ## Disclaimer
 


### PR DESCRIPTION
Keeping a separate paragraph, including header, just for the license
seems a bit excessive. So let's just make it a badge from shields.io
instead!