### PR TITLE
travis-ci: download latest fuse-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - osx
 
 before_script:
-  - wget https://www.fusetools.com/downloads/0.25.0.7511/osx -O fuse-installer.pkg &&
+  - wget https://www.fusetools.com/downloads/latest/beta/osx -O fuse-installer.pkg &&
     sudo installer -pkg fuse-installer.pkg -target /
 
 script:


### PR DESCRIPTION
We now have a shiny new way we can download the latest version of
fuse without having to keep track of URLs, so let's use that.